### PR TITLE
Fix small typo in example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Halbuilder is a simple Java API for generating and consuming HAL documents confo
       .withProperty("summary", "An example list")
       .withSubresource("td:owner", owner);
 
-    String xml = halResource.renderContent(ResourceFactory.HALXML);
-    String json = halResource.renderContent(ResourceFactory.HALJSON);
+    String xml = halResource.renderContent(ResourceFactory.HAL_XML);
+    String json = halResource.renderContent(ResourceFactory.HAL_JSON);
 
 ### Reading Local Resources
 


### PR DESCRIPTION
The example in the README contains a small typo in the constant names.
