### PR TITLE
Make ResourceFactory.readResource pluggable

### DIFF
--- a/src/main/java/com/theoryinpractise/halbuilder/ResourceFactory.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/ResourceFactory.java
@@ -29,6 +29,8 @@ import java.util.TreeMap;
 import static java.lang.String.format;
 
 public class ResourceFactory {
+    public static final char JSON_CHARACTER = '{';
+    public static final char XML_CHARACTER = '<';
 
     public static final String HAL_XML = "application/hal+xml";
     public static final String HAL_JSON = "application/hal+json";
@@ -51,8 +53,8 @@ public class ResourceFactory {
         this.baseHref = baseHref;
         this.contentRenderers.put(new ContentType(HAL_XML), XmlRenderer.class);
         this.contentRenderers.put(new ContentType(HAL_JSON), JsonRenderer.class);
-        this.resourceReaders.put('<', XmlResourceReader.class);
-        this.resourceReaders.put('{', JsonResourceReader.class);
+        this.resourceReaders.put(XML_CHARACTER, XmlResourceReader.class);
+        this.resourceReaders.put(JSON_CHARACTER, JsonResourceReader.class);
     }
 
     public String getBaseHref() {

--- a/src/main/java/com/theoryinpractise/halbuilder/ResourceFactory.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/ResourceFactory.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.theoryinpractise.halbuilder.impl.ContentType;
+import com.theoryinpractise.halbuilder.impl.api.ResourceReader;
 import com.theoryinpractise.halbuilder.impl.json.JsonRenderer;
 import com.theoryinpractise.halbuilder.impl.json.JsonResourceReader;
 import com.theoryinpractise.halbuilder.impl.resources.MutableResource;
@@ -19,6 +20,7 @@ import com.theoryinpractise.halbuilder.spi.ResourceException;
 
 import java.io.BufferedReader;
 import java.io.Reader;
+import java.lang.reflect.Constructor;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +34,7 @@ public class ResourceFactory {
     public static final String HAL_JSON = "application/hal+json";
 
     private Map<ContentType, Class<? extends Renderer>> contentRenderers = Maps.newHashMap();
+    private Map<Character, Class<? extends ResourceReader>> resourceReaders = Maps.newHashMap();
     private TreeMap<String, String> namespaces = Maps.newTreeMap(Ordering.usingToString());
     private List<Link> links = Lists.newArrayList();
     private String baseHref;
@@ -48,6 +51,8 @@ public class ResourceFactory {
         this.baseHref = baseHref;
         this.contentRenderers.put(new ContentType(HAL_XML), XmlRenderer.class);
         this.contentRenderers.put(new ContentType(HAL_JSON), JsonRenderer.class);
+        this.resourceReaders.put('<', XmlResourceReader.class);
+        this.resourceReaders.put('{', JsonResourceReader.class);
     }
 
     public String getBaseHref() {
@@ -100,13 +105,9 @@ public class ResourceFactory {
             char firstChar = (char) bufferedReader.read();
             bufferedReader.reset();
 
-            if (firstChar == '<') {
-                return new XmlResourceReader(this).read(bufferedReader);
-            } else if (firstChar == '{') {
-                return new JsonResourceReader(this).read(bufferedReader);
-            } else {
-                throw new ResourceException("Unknown resource format");
-            }
+            Class<? extends ResourceReader> readerClass = resourceReaders.get(firstChar);
+            Constructor<? extends ResourceReader> readerConstructor = readerClass.getConstructor(ResourceFactory.class);
+            return readerConstructor.newInstance(this).read(bufferedReader);
         } catch (Exception e) {
             throw new ResourceException(e);
         }

--- a/src/main/java/com/theoryinpractise/halbuilder/ResourceFactory.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/ResourceFactory.java
@@ -64,6 +64,11 @@ public class ResourceFactory {
         return this;
     }
 
+    public ResourceFactory withReader(Character character, Class<? extends ResourceReader> readerClass) {
+        resourceReaders.put(character, readerClass);
+        return this;
+    }
+
     public ResourceFactory withNamespace(String namespace, String url) {
         if (namespaces.containsKey(namespace)) {
             throw new ResourceException(format("Duplicate namespace '%s' found for resource factory", namespace));

--- a/src/test/java/com/theoryinpractise/halbuilder/ResourceFactoryTest.java
+++ b/src/test/java/com/theoryinpractise/halbuilder/ResourceFactoryTest.java
@@ -1,0 +1,44 @@
+package com.theoryinpractise.halbuilder;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+import org.testng.annotations.Test;
+
+import com.theoryinpractise.halbuilder.impl.api.ResourceReader;
+import com.theoryinpractise.halbuilder.spi.ReadableResource;
+
+public class ResourceFactoryTest {
+
+    @Test
+    public void testWithXmlReader() {
+        ResourceFactory resourceFactory = new ResourceFactory()
+                .withReader(ResourceFactory.XML_CHARACTER, DummyResourceReader.class);
+        ReadableResource resource = resourceFactory.readResource(new InputStreamReader(
+                ResourceFactoryTest.class.getResourceAsStream("example.xml")));
+        assertThat(resource.getProperties().get("name")).isEqualTo("dummy");
+    }
+
+    @Test
+    public void testWithJsonReader() {
+        ResourceFactory resourceFactory = new ResourceFactory()
+                .withReader(ResourceFactory.JSON_CHARACTER, DummyResourceReader.class);
+        ReadableResource resource = resourceFactory.readResource(new InputStreamReader(
+                ResourceFactoryTest.class.getResourceAsStream("example.json")));
+        assertThat(resource.getProperties().get("name")).isEqualTo("dummy");
+    }
+
+    public static class DummyResourceReader implements ResourceReader {
+        private final ResourceFactory resourceFactory;
+
+        public DummyResourceReader(ResourceFactory resourceFactory) {
+            this.resourceFactory = resourceFactory;
+        }
+
+        public ReadableResource read(Reader source) {
+            return resourceFactory.newResource("/dummy").withProperty("name", "dummy");
+        }
+    }
+}

--- a/src/test/java/com/theoryinpractise/halbuilder/ResourceFactoryTest.java
+++ b/src/test/java/com/theoryinpractise/halbuilder/ResourceFactoryTest.java
@@ -15,7 +15,7 @@ public class ResourceFactoryTest {
     @Test
     public void testWithXmlReader() {
         ResourceFactory resourceFactory = new ResourceFactory()
-                .withReader(ResourceFactory.XML_CHARACTER, DummyResourceReader.class);
+                .withReader(ResourceFactory.HAL_XML, DummyResourceReader.class);
         ReadableResource resource = resourceFactory.readResource(new InputStreamReader(
                 ResourceFactoryTest.class.getResourceAsStream("example.xml")));
         assertThat(resource.getProperties().get("name")).isEqualTo("dummy");
@@ -24,7 +24,7 @@ public class ResourceFactoryTest {
     @Test
     public void testWithJsonReader() {
         ResourceFactory resourceFactory = new ResourceFactory()
-                .withReader(ResourceFactory.JSON_CHARACTER, DummyResourceReader.class);
+                .withReader(ResourceFactory.HAL_JSON, DummyResourceReader.class);
         ReadableResource resource = resourceFactory.readResource(new InputStreamReader(
                 ResourceFactoryTest.class.getResourceAsStream("example.json")));
         assertThat(resource.getProperties().get("name")).isEqualTo("dummy");


### PR DESCRIPTION
Instead of trying to extend the existing JSON reader to implement issue #21, I elected to make the reader pluggable. This makes it possible to experiment with different renderers and readers.

I kept the original selector on the first character of the stream because it keeps the extension simple.

Usage:

``` java
resourceFactory.withReader('{', MyJsonResourceReader.class);
```

I added tests but no documentation, in order to conform to existing practices. ;-) Seriously, I would add some docs if there was some skeleton available.
