### PR TITLE
Make embedded resources conform to HAL spec

### DIFF
--- a/src/main/java/com/theoryinpractise/halbuilder/impl/json/JsonRenderer.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/impl/json/JsonRenderer.java
@@ -1,10 +1,7 @@
 package com.theoryinpractise.halbuilder.impl.json;
 
 import com.google.common.base.Function;
-import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
@@ -22,6 +19,7 @@ import java.io.Writer;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import static com.theoryinpractise.halbuilder.impl.api.Support.CURIE;
 import static com.theoryinpractise.halbuilder.impl.api.Support.EMBEDDED;
@@ -29,9 +27,7 @@ import static com.theoryinpractise.halbuilder.impl.api.Support.HREF;
 import static com.theoryinpractise.halbuilder.impl.api.Support.HREFLANG;
 import static com.theoryinpractise.halbuilder.impl.api.Support.LINKS;
 import static com.theoryinpractise.halbuilder.impl.api.Support.NAME;
-import static com.theoryinpractise.halbuilder.impl.api.Support.SELF;
 import static com.theoryinpractise.halbuilder.impl.api.Support.TITLE;
-import static com.theoryinpractise.halbuilder.impl.api.Support.WHITESPACE_SPLITTER;
 
 
 public class JsonRenderer<T> implements Renderer<T> {
@@ -54,91 +50,73 @@ public class JsonRenderer<T> implements Renderer<T> {
         return Optional.absent();
     }
 
-    private void renderJson(JsonGenerator g, ReadableResource resource, boolean embedded) throws IOException {
+        private void renderJson(JsonGenerator g, ReadableResource resource, boolean embedded) throws IOException {
+            if (!resource.getCanonicalLinks().isEmpty() || (!embedded && !resource.getNamespaces().isEmpty())) {
+                g.writeObjectFieldStart(LINKS);
 
-        final Link resourceLink = resource.getResourceLink();
-        final String href = resourceLink.getHref();
+                List<Link> links = Lists.newArrayList();
 
-        if (!resource.getCanonicalLinks().isEmpty() || (!embedded && !resource.getNamespaces().isEmpty())) {
-            g.writeObjectFieldStart(LINKS);
-
-            List<Link> links = Lists.newArrayList();
-
-            // Include namespaces as links when not embedded
-            if (!embedded) {
-                for (Map.Entry<String, String> entry : resource.getNamespaces().entrySet()) {
-                    links.add(new Link(null, entry.getValue(), CURIE, Optional.of(entry.getKey()), Optional.<String>absent(), Optional.<String>absent()));
+                // Include namespaces as links when not embedded
+                if (!embedded) {
+                    for (Map.Entry<String, String> entry : resource.getNamespaces().entrySet()) {
+                        links.add(new Link(null, entry.getValue(), CURIE, Optional.of(entry.getKey()), Optional.<String>absent(), Optional.<String>absent()));
+                    }
                 }
-            }
 
-            // Add resource links
-            links.addAll(resource.getLinks());
+                // Add resource links
+                links.addAll(resource.getLinks());
 
-            // Partition resource links by rel
-            Multimap<String, Link> linkMap = Multimaps.index(links, new Function<Link, String>() {
-                public String apply(@Nullable Link link) {
-                    return link.getRel();
-                }
-            });
+                // Partition resource links by rel
+                Multimap<String, Link> linkMap = Multimaps.index(links, new Function<Link, String>() {
+                    public String apply(@Nullable Link link) {
+                        return link.getRel();
+                    }
+                });
 
-            for (Map.Entry<String, Collection<Link>> linkEntry : linkMap.asMap().entrySet()) {
-                if (linkEntry.getValue().size() == 1) {
-                    Link link = linkEntry.getValue().iterator().next();
-                    g.writeObjectFieldStart(linkEntry.getKey());
-                    writeJsonLinkContent(g, link);
-                    g.writeEndObject();
-                } else {
-                    g.writeArrayFieldStart(linkEntry.getKey());
-                    for (Link link : linkEntry.getValue()) {
-                        g.writeStartObject();
+                for (Map.Entry<String, Collection<Link>> linkEntry : linkMap.asMap().entrySet()) {
+                    if (linkEntry.getValue().size() == 1) {
+                        Link link = linkEntry.getValue().iterator().next();
+                        g.writeObjectFieldStart(linkEntry.getKey());
                         writeJsonLinkContent(g, link);
                         g.writeEndObject();
-                    }
-                    g.writeEndArray();
-                }
-            }
-            g.writeEndObject();
-        }
-
-        for (Map.Entry<String, Object> entry : resource.getProperties().entrySet()) {
-            g.writeObjectField(entry.getKey(), entry.getValue());
-        }
-
-        if (!resource.getResources().isEmpty()) {
-            g.writeObjectFieldStart(EMBEDDED);
-
-            Multimap<String, Resource> resourceMap = Multimaps.index(resource.getResources(), new Function<Resource, String>() {
-                public String apply(@Nullable Resource resource) {
-                    List<String> relTypes = Lists.newArrayList(WHITESPACE_SPLITTER.split(resource.getResourceLink().getRel()));
-
-                    Iterables.removeIf(relTypes, new Predicate<String>() {
-                        public boolean apply(@Nullable String s) {
-                            return SELF.equals(s);
+                    } else {
+                        g.writeArrayFieldStart(linkEntry.getKey());
+                        for (Link link : linkEntry.getValue()) {
+                            g.writeStartObject();
+                            writeJsonLinkContent(g, link);
+                            g.writeEndObject();
                         }
-                    });
-
-                    return Joiner.on(" ").join(relTypes);
+                        g.writeEndArray();
+                    }
                 }
-            });
+                g.writeEndObject();
+            }
 
-            for (Map.Entry<String, Collection<Resource>> resourceEntry : resourceMap.asMap().entrySet()) {
-                if (resourceEntry.getValue().size() == 1) {
-                    g.writeObjectFieldStart(resourceEntry.getKey());
-                    ReadableResource subResource = resourceEntry.getValue().iterator().next();
-                    renderJson(g, subResource, true);
-                    g.writeEndObject();
-                } else {
-                    g.writeArrayFieldStart(resourceEntry.getKey());
-                    for (ReadableResource subResource : resourceEntry.getValue()) {
-                        g.writeStartObject();
+            for (Map.Entry<String, Object> entry : resource.getProperties().entrySet()) {
+                g.writeObjectField(entry.getKey(), entry.getValue());
+            }
+
+            if (!resource.getResources().isEmpty()) {
+                g.writeObjectFieldStart(EMBEDDED);
+
+                for (Entry<String, List<Resource>> resourceEntry : resource.getResources().entrySet()) {
+                    if (resourceEntry.getValue().size() == 1) {
+                        g.writeObjectFieldStart(resourceEntry.getKey());
+                        ReadableResource subResource = resourceEntry.getValue().iterator().next();
                         renderJson(g, subResource, true);
                         g.writeEndObject();
+                    } else {
+                        g.writeArrayFieldStart(resourceEntry.getKey());
+                        for (ReadableResource subResource : resourceEntry.getValue()) {
+                            g.writeStartObject();
+                            renderJson(g, subResource, true);
+                            g.writeEndObject();
+                        }
+                        g.writeEndArray();
                     }
-                    g.writeEndArray();
                 }
             }
         }
-    }
 
     private void writeJsonLinkContent(JsonGenerator g, Link link) throws IOException {
         g.writeStringField(HREF, link.getHref());

--- a/src/main/java/com/theoryinpractise/halbuilder/impl/resources/BaseResource.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/impl/resources/BaseResource.java
@@ -257,7 +257,7 @@ public abstract class BaseResource implements ReadableResource {
     public ImmutableResource toImmutableResource() {
         return new ImmutableResource(resourceFactory, getNamespaces(), getCanonicalLinks(), getProperties(), getResources());
     }
-
+    
     @Override
     public int hashCode() {
         int h = namespaces.hashCode();
@@ -280,12 +280,12 @@ public abstract class BaseResource implements ReadableResource {
         }
         BaseResource that = (BaseResource) obj;
         boolean e = this.namespaces.equals(that.namespaces);
-        e = e && this.links.equals(that.links);
-        e = e && this.properties.equals(that.properties);
-        e = e && this.resources.equals(that.resources);
+        e &= this.links.equals(that.links);
+        e &= this.properties.equals(that.properties);
+        e &= this.resources.equals(that.resources);
         return e;
     }
-
+    
     @Override
     public String toString() {
         Optional<Link> href = getLinkByRel("self");

--- a/src/main/java/com/theoryinpractise/halbuilder/impl/resources/BaseResource.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/impl/resources/BaseResource.java
@@ -252,7 +252,7 @@ public abstract class BaseResource implements ReadableResource {
     public ImmutableResource toImmutableResource() {
         return new ImmutableResource(resourceFactory, getNamespaces(), getCanonicalLinks(), getProperties(), getResources());
     }
-    
+
     @Override
     public int hashCode() {
         int h = namespaces.hashCode();
@@ -275,12 +275,12 @@ public abstract class BaseResource implements ReadableResource {
         }
         BaseResource that = (BaseResource) obj;
         boolean e = this.namespaces.equals(that.namespaces);
-        e &= this.links.equals(that.links);
-        e &= this.properties.equals(that.properties);
-        e &= this.resources.equals(that.resources);
+        e = e && this.links.equals(that.links);
+        e = e && this.properties.equals(that.properties);
+        e = e && this.resources.equals(that.resources);
         return e;
     }
-    
+
     @Override
     public String toString() {
         Optional<Link> href = getLinkByRel("self");

--- a/src/main/java/com/theoryinpractise/halbuilder/impl/resources/ImmutableResource.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/impl/resources/ImmutableResource.java
@@ -17,7 +17,8 @@ public class ImmutableResource extends BaseResource {
     private final Link resourceLink;
 
     public ImmutableResource(ResourceFactory resourceFactory,
-                             Map<String, String> namespaces, List<Link> links, Map<String, Object> properties, List<Resource> resources) {
+                             Map<String, String> namespaces, List<Link> links, Map<String, Object> properties,
+                             Map<String, List<Resource>> resources) {
         super(resourceFactory);
         this.namespaces = namespaces;
         this.links = links;

--- a/src/main/java/com/theoryinpractise/halbuilder/impl/resources/MutableResource.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/impl/resources/MutableResource.java
@@ -22,6 +22,9 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.net.URI;
+import java.util.List;
+
+import org.testng.collections.Lists;
 
 import static com.theoryinpractise.halbuilder.impl.api.Support.WHITESPACE_SPLITTER;
 import static java.lang.String.format;
@@ -189,8 +192,12 @@ public class MutableResource extends BaseResource implements Resource {
     }
 
     public MutableResource withSubresource(String rel, Resource resource) {
-        resource.withLink(resource.getResourceLink().getHref(), rel);
-        resources.add(resource);
+        List<Resource> resourceList = resources.get(rel);
+        if (resourceList == null) {
+            resourceList = Lists.newArrayList();
+            resources.put(rel, resourceList);
+        }
+        resourceList.add(resource);
         return this;
     }
 

--- a/src/main/java/com/theoryinpractise/halbuilder/spi/Link.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/spi/Link.java
@@ -49,7 +49,7 @@ public class Link {
     public Optional<String> getHreflang() {
         return hreflang;
     }
-    
+
     @Override
     public int hashCode() {
         int h = href.hashCode();
@@ -59,7 +59,7 @@ public class Link {
         h += hreflang.hashCode();
         return h;
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {
@@ -73,10 +73,10 @@ public class Link {
         }
         Link that = (Link) obj;
         boolean e = this.href.equals(that.href);
-        e &= this.rel.equals(that.rel);
-        e &= this.name.equals(that.name);
-        e &= this.title.equals(that.title);
-        e &= this.hreflang.equals(that.hreflang);
+        e = e && this.rel.equals(that.rel);
+        e = e && this.name.equals(that.name);
+        e = e && this.title.equals(that.title);
+        e = e && this.hreflang.equals(that.hreflang);
         return e;
     }
 

--- a/src/main/java/com/theoryinpractise/halbuilder/spi/Link.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/spi/Link.java
@@ -49,7 +49,7 @@ public class Link {
     public Optional<String> getHreflang() {
         return hreflang;
     }
-
+    
     @Override
     public int hashCode() {
         int h = href.hashCode();
@@ -59,7 +59,7 @@ public class Link {
         h += hreflang.hashCode();
         return h;
     }
-
+    
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {
@@ -73,10 +73,10 @@ public class Link {
         }
         Link that = (Link) obj;
         boolean e = this.href.equals(that.href);
-        e = e && this.rel.equals(that.rel);
-        e = e && this.name.equals(that.name);
-        e = e && this.title.equals(that.title);
-        e = e && this.hreflang.equals(that.hreflang);
+        e &= this.rel.equals(that.rel);
+        e &= this.name.equals(that.name);
+        e &= this.title.equals(that.title);
+        e &= this.hreflang.equals(that.hreflang);
         return e;
     }
 

--- a/src/main/java/com/theoryinpractise/halbuilder/spi/ReadableResource.java
+++ b/src/main/java/com/theoryinpractise/halbuilder/spi/ReadableResource.java
@@ -71,7 +71,7 @@ public interface ReadableResource {
      * Returns an ImmutableList of the resources currently embedded resources.
      * @return A Map
      */
-    List<Resource> getResources();
+    Map<String, List<Resource>> getResources();
 
     /**
      * Returns whether this resource is satisfied by the provided Contact.

--- a/src/test/java/com/theoryinpractise/halbuilder/ResourceReaderTest.java
+++ b/src/test/java/com/theoryinpractise/halbuilder/ResourceReaderTest.java
@@ -57,7 +57,8 @@ public class ResourceReaderTest {
         assertThat(resource.getNamespaces()).hasSize(2);
         assertThat(resource.getCanonicalLinks()).hasSize(3);
         assertThat(resource.getResources()).hasSize(1);
-        assertThat(resource.getResources().iterator().next().getProperties().get("name")).isEqualTo("Example User");
+        assertThat(resource.getResources().values().iterator().next().iterator().next().getProperties().get("name"))
+                .isEqualTo("Example User");
     }
 
     @Test(expectedExceptions = ResourceException.class)

--- a/src/test/resources/com/theoryinpractise/halbuilder/exampleWithMultipleSubresources.json
+++ b/src/test/resources/com/theoryinpractise/halbuilder/exampleWithMultipleSubresources.json
@@ -23,7 +23,7 @@
   "_embedded" : {
     "ns:user role:admin" : [ {
       "_links" : {
-        "ns:user role:admin self" : {
+        "self" : {
           "href" : "https://example.com/user/11"
         }
       },
@@ -34,7 +34,7 @@
       "optional" : true
     }, {
       "_links" : {
-        "ns:user role:admin self" : {
+        "self" : {
           "href" : "https://example.com/user/12"
         }
       },

--- a/src/test/resources/com/theoryinpractise/halbuilder/exampleWithMultipleSubresources.xml
+++ b/src/test/resources/com/theoryinpractise/halbuilder/exampleWithMultipleSubresources.xml
@@ -1,14 +1,14 @@
 <resource xmlns:ns="https://example.com/apidocs/accounts" xmlns:role="https://example.com/apidocs/roles" href="https://example.com/api/customer/123456">
   <link rel="ns:parent" href="https://example.com/api/customer/1234" name="bob" title="The Parent" hreflang="en" />
   <link rel="ns:users" href="https://example.com/api/customer/123456?users" />
-  <resource href="https://example.com/user/11" rel="ns:user role:admin self">
+  <resource href="https://example.com/user/11" rel="ns:user role:admin">
     <age>32</age>
     <expired>false</expired>
     <id>11</id>
     <name>Example User</name>
     <optional>true</optional>
   </resource>
-  <resource href="https://example.com/user/12" rel="ns:user role:admin self">
+  <resource href="https://example.com/user/12" rel="ns:user role:admin">
     <age>32</age>
     <expired>false</expired>
     <id>12</id>

--- a/src/test/resources/com/theoryinpractise/halbuilder/exampleWithSubresource.json
+++ b/src/test/resources/com/theoryinpractise/halbuilder/exampleWithSubresource.json
@@ -23,7 +23,7 @@
   "_embedded" : {
     "ns:user role:admin" : {
       "_links" : {
-        "ns:user role:admin self" : {
+        "self" : {
           "href" : "https://example.com/user/11"
         }
       },

--- a/src/test/resources/com/theoryinpractise/halbuilder/exampleWithSubresource.xml
+++ b/src/test/resources/com/theoryinpractise/halbuilder/exampleWithSubresource.xml
@@ -1,7 +1,7 @@
 <resource xmlns:ns="https://example.com/apidocs/accounts" xmlns:role="https://example.com/apidocs/roles" href="https://example.com/api/customer/123456">
   <link rel="ns:parent" href="https://example.com/api/customer/1234" name="bob" title="The Parent" hreflang="en" />
   <link rel="ns:users" href="https://example.com/api/customer/123456?users" />
-  <resource href="https://example.com/user/11" rel="ns:user role:admin self">
+  <resource href="https://example.com/user/11" rel="ns:user role:admin">
     <age>32</age>
     <expired>false</expired>
     <id>11</id>


### PR DESCRIPTION
As I noticed in issue #24, rendered embedded resources do not conform to the HAL spec. This pull request contains my attempt to fix that.

There is one test that still fails: `ResourceTest.testUndeclaredResourceNamespace`. This test checks that `Resource.withSubresource` will not accept a subresource that uses an undeclared namespace. There must be an existing way of throwing an exception in this case, but I can't seem to find it. Can you tell me where to look?

If you accept this pull request in its current form, please follow up with a fix for the failing test.
